### PR TITLE
add links to download extension in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,18 @@ Browser extension providing essential tools for 42 students including logtime tr
 
 ## Installation
 
-### Chrome
+[<img src="https://lh4.ggpht.com/x-plP9YZXhCaiDkTKQ5S29PwLmdi4feEKrMOtQle4NuoOaUgKUMH9pPWIg91da3anhSmw-G8erEIuU0d" width="128" alt="Google Chrome" title="Download for Google Chrome">](https://chromewebstore.google.com/detail/orbit/aehigcljfmpiklaeflkpnekohfgnbdpf)
+[<img src="https://www.mozilla.org/media/img/structured-data/logo-firefox-browser.fbc7ffbb50fd.png" width="128" alt="Mozilla Firefox" title="Download for Mozilla Firefox">](https://github.com/Gwilhoa/Orbit/releases/latest/download/Orbit.xpi)
+
+### Manual
+
+#### Chrome
 1. Download the extension files
 2. Open Chrome and go to `chrome://extensions/`
 3. Enable "Developer mode"
 4. Click "Load unpacked" and select the extension directory
 
-### Firefox
+#### Firefox
 **Option 1: Temporary Installation (Recommended for Development)**
 1. Open Firefox and go to `about:debugging`
 2. Click "This Firefox" in the sidebar


### PR DESCRIPTION
This pull request updates the installation instructions in the `README.md` to make it easier for users to install the browser extension, adding direct download links and improving clarity for both Chrome and Firefox users.

**Installation instructions improvements:**

* Added prominent download badges with direct links for Google Chrome and Mozilla Firefox to simplify the installation process.
* Clarified and reorganized manual installation steps for both Chrome and Firefox, separating them into distinct sections for better readability.